### PR TITLE
 curl replaced with nc for healthchecks as it covers more use cases

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM debian:stable-slim
 LABEL maintainer="docker@llamaq.com"
 
 RUN apt-get update \
-  && apt-get install --no-install-recommends --no-install-suggests -y curl nginx nginx-extras  \
+  && apt-get install --no-install-recommends --no-install-suggests -y \
+    netcat-openbsd nginx nginx-extras  \
   && apt-get -y clean && apt-get purge -y --auto-remove && rm -rf /var/lib/apt/lists/*
 
 # forward request and error logs to docker log collector
@@ -16,5 +17,7 @@ ENV PUID=1000 PGID=1000
 COPY entrypoint.sh /
 RUN chmod +x entrypoint.sh
 
-HEALTHCHECK CMD curl --fail http://localhost:80 || exit 1
+HEALTHCHECK --interval=1m --timeout=10s \
+  CMD nc -z localhost 80 || exit 1
+
 CMD /entrypoint.sh


### PR DESCRIPTION
403 and 404 statuses